### PR TITLE
Rename resumeTex to resumeText and fix styles alignment

### DIFF
--- a/src/components/resume/Education.jsx
+++ b/src/components/resume/Education.jsx
@@ -73,7 +73,7 @@ const Education = () => {
         <p className={`${styles.resumeSubText} text-center`}>
           My Background
         </p>
-        <h2 className={`${styles.resumeTex} text-center`}>
+        <h2 className={`${styles.resumeText} text-center`}>
           Education.
         </h2>
       </motion.div>

--- a/src/components/resume/Experience.jsx
+++ b/src/components/resume/Experience.jsx
@@ -90,7 +90,7 @@ const Experience = () => {
         <p className={`${styles.resumeSubText} text-center`}>
           What I have done so far
         </p>
-        <h2 className={`${styles.resumeTex} text-center`}>
+        <h2 className={`${styles.resumeText} text-center`}>
           Work Experience.
         </h2>
       </motion.div>

--- a/src/styles.js
+++ b/src/styles.js
@@ -12,9 +12,9 @@ const styles = {
     "text-white font-black md:text-[60px] sm:text-[50px] xs:text-[40px] text-[30px]",
   sectionSubText:
     "sm:text-[18px] text-[14px] text-secondary uppercase tracking-wider",
-  resumeTex:"text-white font-black md:text-[30px] sm:text-[50px] xs:text-[20px] text-[15px]",
+  resumeText: "text-white font-black md:text-[30px] sm:text-[50px] xs:text-[20px] text-[15px]",
   resumeSubText:
-  "sm:text-[14px] text-[10px] text-secondary uppercase tracking-wider",
+    "sm:text-[14px] text-[10px] text-secondary uppercase tracking-wider",
 };
 
 export { styles };


### PR DESCRIPTION
## Summary
- rename `resumeTex` style key to `resumeText`
- fix indentation for `resumeSubText`
- update components to use `resumeText`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_689ed2f66c2c832985939cefa0ec9e74