### PR TITLE
fix width utility in About section

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -47,7 +47,7 @@ const About = () => {
           </motion.div>
           <motion.p
             variants={fadeIn("", "", 0.1, 1)}
-            className='mt-4  text-secondary text-[17px] max-w-2 leading-[30px]'
+            className='mt-4  text-secondary text-[17px] max-w-2xl leading-[30px]'
           >
             {`I'm `} a Colombian System Engineer with a strong software testing and IT support background. Transitioning seamlessly into a skilled Frontend Developer, {`I'm `} passionate 
             about crafting user-friendly web applications with CSS, HTML, React.js.
@@ -60,7 +60,7 @@ const About = () => {
 
           <motion.p
             variants={fadeIn("", "", 0.1, 1)}
-            className='mt-4  text-secondary text-[17px] max-w-2 leading-[30px]'
+            className='mt-4  text-secondary text-[17px] max-w-2xl leading-[30px]'
           >
             I excel in API management and thorough testing through tools like Postman, guaranteeing seamless integration of frontend and backend functionalities.
             Versatility defines me – SQL, MySQL, SQLite, MongoDB – I architect data-driven apps with scalable solutions for diverse project needs.


### PR DESCRIPTION
## Summary
- replace `max-w-2` with Tailwind's `max-w-2xl` in About section paragraphs

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm run build` *(fails: vite not found, dependencies not fully installed)*

------
https://chatgpt.com/codex/tasks/task_e_689ed2f393ac8329812c8cce19b7ac47