### PR TITLE
refactor: use shared design tokens

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -45,10 +45,10 @@ const About = () => {
             <p className={styles.sectionSubText}>Introduction</p>
             <h2 className={styles.sectionHeadText}>Overview.</h2>
           </motion.div>
-          <motion.p
-            variants={fadeIn("", "", 0.1, 1)}
-            className='mt-4  text-secondary text-[17px] max-w-2xl leading-[30px]'
-          >
+            <motion.p
+              variants={fadeIn("", "", 0.1, 1)}
+              className={`${styles.paragraphSpacing} ${styles.bodyText} max-w-2xl`}
+            >
             {`I'm `} a Colombian System Engineer with a strong software testing and IT support background. Transitioning seamlessly into a skilled Frontend Developer, {`I'm `} passionate 
             about crafting user-friendly web applications with CSS, HTML, React.js.
             <br/>
@@ -58,10 +58,10 @@ const About = () => {
             
           </motion.p>
 
-          <motion.p
-            variants={fadeIn("", "", 0.1, 1)}
-            className='mt-4  text-secondary text-[17px] max-w-2xl leading-[30px]'
-          >
+            <motion.p
+              variants={fadeIn("", "", 0.1, 1)}
+              className={`${styles.paragraphSpacing} ${styles.bodyText} max-w-2xl`}
+            >
             I excel in API management and thorough testing through tools like Postman, guaranteeing seamless integration of frontend and backend functionalities.
             Versatility defines me – SQL, MySQL, SQLite, MongoDB – I architect data-driven apps with scalable solutions for diverse project needs.
             Driven by meticulousness and problem-solving, I deliver uncompromising quality, exceeding expectations in dynamic environments.

--- a/src/components/Project/ProjectCard.jsx
+++ b/src/components/Project/ProjectCard.jsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import {Tilt} from "react-tilt";
 import { fadeIn} from "../../utils/motion";
 import { github, webIcon } from "../../assets";
+import { styles } from "../../styles";
 
 const ProjectCard =({
   index,
@@ -23,14 +24,14 @@ const ProjectCard =({
           max: 45,
           scale: 1,
           speed: 450}}
-          className=' p-5 rounded-2xl sm:w-[360px] w-full sm:h-full'
+          className={`${styles.cardPadding} rounded-2xl sm:w-[360px] w-full sm:h-full`}
       >
-        <div className=' relative w-full h-full'>
-          <img
-            src={image}
-            alt='project_image'
-            className='w-full h-full object-cover rounded-2xl bg-tertiary p-5'
-          />
+          <div className=' relative w-full h-full'>
+            <img
+              src={image}
+              alt='project_image'
+              className={`w-full h-full object-cover rounded-2xl bg-tertiary ${styles.cardPadding}`}
+            />
           
 
           <div className=' absolute inset-0 flex gap-2 justify-end m-3 card-img_hover'>

--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -18,7 +18,7 @@ const Works = () => {
       <div className='w-full flex '>
         <motion.p
           variants={fadeIn("", "", 0.1, 1)}
-          className='mt-3 text-secondary text-[17px] max-w-3xl leading-[30px]'
+          className={`${styles.paragraphSpacing} ${styles.bodyText} max-w-3xl`}
         >
           Following projects showcases my skills and experience through
           real-world examples of my work. Each project is briefly described with

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,7 +1,17 @@
+/**
+ * Design tokens used across the application.
+ * - bodyText: Base styling for standard paragraph text.
+ * - paragraphSpacing: Consistent top margin for paragraphs.
+ * - cardPadding: Default padding for card-style containers.
+ */
 const styles = {
   paddingX: "sm:px-16 px-6",
   paddingY: "sm:py-16 py-6",
   padding: "sm:px-16 px-6 sm:py-16 py-10",
+
+  bodyText: "text-secondary text-[17px] leading-[30px]",
+  paragraphSpacing: "mt-4",
+  cardPadding: "p-5",
 
   heroHeadText:
     "font-black text-white lg:text-[80px] sm:text-[60px] xs:text-[50px] text-[40px] lg:leading-[98px] mt-2",


### PR DESCRIPTION
## Summary
- add reusable design tokens for body text, paragraphs, and card padding
- refactor components to use design tokens instead of hard-coded values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: see output)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b06900e483298e8d9fc3b61550d8