### PR TITLE
feat: add responsive about section style

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -43,11 +43,11 @@ const About = () => {
 
           <motion.div variants={textVariant()}>
             <p className={styles.sectionSubText}>Introduction</p>
-            <h2 className={styles.sectionHeadText}>Overview.</h2>
+            <h2 className={styles.sectionHeadTextSm}>Overview.</h2>
           </motion.div>
           <motion.p
             variants={fadeIn("", "", 0.1, 1)}
-            className='mt-4  text-secondary text-[17px] max-w-2xl leading-[30px]'
+            className='mt-4 text-secondary max-w-lg text-[15px] leading-[26px]'
           >
             {`I'm `} a Colombian System Engineer with a strong software testing and IT support background. Transitioning seamlessly into a skilled Frontend Developer, {`I'm `} passionate 
             about crafting user-friendly web applications with CSS, HTML, React.js.
@@ -60,7 +60,7 @@ const About = () => {
 
           <motion.p
             variants={fadeIn("", "", 0.1, 1)}
-            className='mt-4  text-secondary text-[17px] max-w-2xl leading-[30px]'
+            className='mt-4 text-secondary max-w-lg text-[15px] leading-[26px]'
           >
             I excel in API management and thorough testing through tools like Postman, guaranteeing seamless integration of frontend and backend functionalities.
             Versatility defines me – SQL, MySQL, SQLite, MongoDB – I architect data-driven apps with scalable solutions for diverse project needs.

--- a/src/styles.js
+++ b/src/styles.js
@@ -10,6 +10,8 @@ const styles = {
 
   sectionHeadText:
     "text-white font-black md:text-[60px] sm:text-[50px] xs:text-[40px] text-[30px]",
+  sectionHeadTextSm:
+    "text-white font-black md:text-[40px] sm:text-[32px] xs:text-[28px] text-[24px]",
   sectionSubText:
     "sm:text-[18px] text-[14px] text-secondary uppercase tracking-wider",
   resumeText: "text-white font-black md:text-[30px] sm:text-[50px] xs:text-[20px] text-[15px]",


### PR DESCRIPTION
## Summary
- add `sectionHeadTextSm` style with smaller responsive font sizes
- use compact heading and paragraph styles in About section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors in unrelated files)*
- `npm run build`
- `npx playwright --version` *(fails: 403 Forbidden)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b062b7b4832982d450c444c1bbb8