### PR TITLE
fix: specify about image width

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -69,9 +69,9 @@ const About = () => {
           </motion.p>
         </div>
 
-        <div className="m-auto w-">
+        <div className="m-auto w-full sm:w-[360px]">
 
-          <Tilt className = "sm:w-full w-[360px]  ">
+          <Tilt className="w-full">
               <motion.div
               variants={fadeIn("left", "spring", 0.5 , 0.75)}
               className='w-full green-pink-gradient p-[1px] rounded-[20px] shadow-card'


### PR DESCRIPTION
## Summary
- fix About profile image container with explicit width

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 207 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a6b0647d6c8329929f54611e8fc7f1