### PR TITLE
fix(hero): mount ModelCanvas without extra whitespace

### DIFF
--- a/src/components/Portfolio/Hero.jsx
+++ b/src/components/Portfolio/Hero.jsx
@@ -88,7 +88,7 @@ const Hero = () => {
         <div className='w-2/3 h-2/3 m-auto'>
 
           
-          < ModelCanvas />
+        <ModelCanvas />
         </div>
         <StarsCanvas/>
       </div>


### PR DESCRIPTION
## Summary
- remove stray whitespace so Hero renders `<ModelCanvas />`

## Testing
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d02613588329bdaa5e5dc6496ecd