### PR TITLE
Fix GLTF model path for avatar model

### DIFF
--- a/src/components/Portfolio/canvas/Model3d.jsx
+++ b/src/components/Portfolio/canvas/Model3d.jsx
@@ -4,8 +4,10 @@ import { OrbitControls, Preload, useGLTF } from "@react-three/drei";
 
 import CanvasLoader from "../Loader";
 
-const Avatar = ({isMobile}) => {
-  const avatar = useGLTF("./avatar/avatar.gltf");
+const AVATAR_URL = "/avatar/avatar.gltf";
+
+const Avatar = ({ isMobile }) => {
+  const avatar = useGLTF(AVATAR_URL);
   
   return (
     <mesh >
@@ -26,8 +28,8 @@ const Avatar = ({isMobile}) => {
         // rotation={[0, 0, 0]}
       />
     </mesh>
-  )
-}
+  );
+};
 
 const ModelCanvas = () => {
 
@@ -55,8 +57,8 @@ const ModelCanvas = () => {
   }, []);
 
 
-  return(
-    <Canvas className = {" sm:basis-1/3 sm:cursor-pointer sm:block h-1 "}
+  return (
+    <Canvas className={" sm:basis-1/3 sm:cursor-pointer sm:block h-1 "}
       frameloop='demand'
       dpr={[1, 2]}
       gl={{ preserveDrawingBuffer: true }}
@@ -70,13 +72,15 @@ const ModelCanvas = () => {
         enableZoom={false}
         maxPolarAngle={Math.PI / 2}
         minPolarAngle={Math.PI / 2}
-        
+
       />
-      <Avatar isMobile = {isMobile}/>
+      <Avatar isMobile={isMobile} />
       </Suspense>
       <Preload all />
       </Canvas>
-  )
-}
+  );
+};
 
-export default ModelCanvas
+useGLTF.preload(AVATAR_URL);
+
+export default ModelCanvas;


### PR DESCRIPTION
## Summary
- use absolute path for avatar GLTF model and preload it

## Testing
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_68a6d02684a88329b5e667f7195270b5